### PR TITLE
Route header used to route requests if available

### DIFF
--- a/sip.js
+++ b/sip.js
@@ -1039,7 +1039,9 @@ function makeTransactionLayer(options, transport) {
 
       var transaction = rq.method === 'INVITE' ? createInviteClientTransaction : createClientTransaction;
 
-      resolve(parseUri(rq.uri), function(address) {
+      var hop = rq.headers.route || rq.uri;
+
+      resolve(parseUri(hop), function(address) {
         var onresponse;
 
         function next() {


### PR DESCRIPTION
I needed to add this feature to allow sending sip messages targeted to a domain that is not resolvable by DNS.   It offers the typical outbound proxy functionality of other SIP stacks.
