### PR TITLE
fix handling of lr so route headers created from object are supported.

### DIFF
--- a/sip.js
+++ b/sip.js
@@ -1219,7 +1219,7 @@ exports.makeTransactionLayer = makeTransactionLayer;
 
 exports.create = function(options, callback) {
   var errorLog = (options.logger && options.logger.error) || function() {};
-  
+
   var transport = makeTransport(options, function(m,remote) {
     try {
       var t = m.method ? transaction.getServer(m) : transaction.getClient(m);


### PR DESCRIPTION
I noticed that requests that I was creating from objects weren't being handled properly by the module because the hop was being created from just the uri object in the route.

When I create a route header like this:
route: [{ uri: 'sip:' + this.outboundproxy , params: {lr: ''}}];

The topmost route header was being stripped and being replaced with the contact, because the hop.params.lr was undefined even though the route header I created had lr defined.

This fix tests the route header created by the user and doesn't throw an error if params is not defined.
