### PR TITLE
reuse m.proto when stringifying sdp

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -75,7 +75,7 @@ var stringifiers = {
     return [c.nettype || 'IN', c.addrtype || 'IP4', c.address].join(' ');
   },
   m: function(m) {
-    return [m.media || 'audio', m.port, m.transport || 'RTP/AVP', m.fmt.join(' ')].join(' ');
+    return [m.media || 'audio', m.port, m.proto || 'RTP/AVP', m.fmt.join(' ')].join(' ');
   }
 };
 


### PR DESCRIPTION
When stringifying a sdp that was parsed with sdp.js there is a bug where sdp.js uses m.transport instead of m.proto. This was resulting in RTP/SAVFP webrtc rtp profiles being stringified with the wrong rtp profile (RTP/AVP) because m.transport didn't exist.
