### PR TITLE
Remove case sensitivity for scheme 'digest'

### DIFF
--- a/digest.js
+++ b/digest.js
@@ -84,7 +84,7 @@ function numberTo8Hex(n) {
 
 function findDigestRealm(headers, realm) {
   if(!realm) return headers && headers[0];
-  return headers && headers.filter(function(x) { return x.scheme === 'Digest' && unq(x.realm) === realm; })[0];
+  return headers && headers.filter(function(x) { return x.scheme.toLowerCase() === 'digest' && unq(x.realm) === realm; })[0];
 }
 
 function selectQop(challenge, preference) {


### PR DESCRIPTION
Came across a number of SIP proxies that use variations like 'DIGEST' etc.
