### PR TITLE
Update sip.js - stringify() - keep headers whose value is 0

### DIFF
--- a/sip.js
+++ b/sip.js
@@ -356,7 +356,7 @@ function stringify(m) {
   m.headers['content-length'] = (m.content || '').length;
 
   for(var n in m.headers) {
-    if(m.headers[n]) {
+    if(typeof m.headers[n] !== "undefined") {
       if(typeof m.headers[n] === 'string' || !stringifiers[n]) 
         s += prettifyHeaderName(n) + ': ' + m.headers[n] + '\r\n';
       else


### PR DESCRIPTION
When the content was not set or was simply '', its length was 0, and so the content-length header had 0 as a value.
When evaluated with m.headers[n] (n = "content-length)", it came out as false, resulting in the Content-Length header not appearing when its value was 0.

Testing the type of the header instead allows for the "Content-Length: 0" header to exist.