### PR TITLE
Fixed stringifing messages with no VIA headers, such as a 404

### DIFF
--- a/sip.js
+++ b/sip.js
@@ -296,7 +296,12 @@ exports.stringifyAuthHeader = stringifyAuthHeader;
 var stringifiers = {
   via: function(h) {
     return h.map(function(via) {
-      return 'Via: SIP/'+stringifyVersion(via.version)+'/'+via.protocol.toUpperCase()+' '+via.host+(via.port?':'+via.port:'')+stringifyParams(via.params)+'\r\n';
+      if(via.host) {
+        return 'Via: SIP/'+stringifyVersion(via.version)+'/'+via.protocol.toUpperCase()+' '+via.host+(via.port?':'+via.port:'')+stringifyParams(via.params)+'\r\n';
+      }
+      else {
+        return '';
+      }
     }).join('');
   },
   to: function(h) {


### PR DESCRIPTION
With the current version, if you try to send a SIP message to an IP/port that does not have a process listening for SIP, and you try to stringily the response, an uncaught exception is thrown as it tries to call `toUpperCase()` on the undefined protocol string.

```
/Users/nguyer/Code/sip.js/sip.js:299
  return 'Via: SIP/'+stringifyVersion(via.version)+'/'+via.protocol.toUpperCas
                                                                    ^
TypeError: Cannot call method 'toUpperCase' of undefined
    at /Users/nguyer/Code/sip.js/sip.js:299:73
    at Array.map (native)
    at Object.stringifiers.via (/Users/nguyer/Code/sip.js/sip.js:298:14)
    at Object.stringify (/Users/nguyer/Code/sip.js/sip.js:363:29)
    at /Users/nguyer/Code/sendsip/app.js:78:18
    at next (/Users/nguyer/Code/sip.js/sip.js:1241:7)
    at sequentialSearch (/Users/nguyer/Code/sip.js/sip.js:1255:3)
    at /Users/nguyer/Code/sip.js/sip.js:1358:13
    at /Users/nguyer/Code/sip.js/sip.js:1335:13
    at Object.send (/Users/nguyer/Code/sip.js/sip.js:1339:11)
```

This is fixed with this patch. If no hostname is present in the VIA header, it is invalid anyway, and will not be stringified with the rest of the message.