### PR TITLE
Match variations of 'call-id' header.

### DIFF
--- a/sip.js
+++ b/sip.js
@@ -1165,7 +1165,7 @@ function createClientTransaction(rq, transport, tu, cleanup) {
 function makeTransactionId(m) {
   if(m.method === 'ACK')
     return ['INVITE', m.headers['call-id'], m.headers.via[0].params.branch].join();
-  return [m.headers.cseq.method, m.headers['call-id'], m.headers.via[0].params.branch].join();
+  return [m.headers.cseq.method, (m.headers['call-id'] || m.headers['Call-ID'] || m.headers['i']), m.headers.via[0].params.branch].join();
 }
 
 function makeTransactionLayer(options, transport) {


### PR DESCRIPTION
Modifies makeTransactionId to match 'Call-ID' and 'i' in addtion to 'call-id' when starting a new transaction.

fixes #76 