### PR TITLE
Specified ws.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=0.2.2"
   },
   "dependencies": {
-    "ws": "*"
+    "ws": "1.1.1"
   },
   "devDependencies": {
     "coffee-script": "~1.6.2"


### PR DESCRIPTION
ws.js 1.1.1 version is the last one that work with sip.js without the need of ES6