### PR TITLE
Fixing vunerability to flood with statefull connections.

### DIFF
--- a/doc/api.markdown
+++ b/doc/api.markdown
@@ -113,6 +113,8 @@ Starts SIP protocol.
 * `publicAddress`, `hostname` - address and hostname to be used within sip.js generated local uris and via headers. Sip.js will use `options.publicAddress` when
   it's defined, then fallback to `options.hostname` and the fallback to value returned by node.js `os.hostname()` API.
 * `ws_port` - port for WebSockets transport. To enable WebSockets transport, this field is required; no default provided.
+* `maxBytesHeaders` - (For TCP and TLS ) Max allowed length in bytes of a SIP message headers ( without content ). ; default: 60480.
+* `maxContentLength` - (For TCP and TLS ) Max allowed content length for a SIP message. ; default: 604800.
 
 
 `onRequest` - callback to be called on new request arrival. It is expected to be a function of two arguments

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "sip",
+  "version": "0.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "coffee-script": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+      "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
+      "dev": true
+    },
+    "uws": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/uws/-/uws-8.14.1.tgz",
+      "integrity": "sha1-3glhnzBfYXTVUWqcaULLEgkEsgs="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "homepage": "http://github.com/kirm/sip.js",
   "author": "Kirill Mikhailov <kirill.mikhailov@gmail.com>",
   "main": "sip",
+  "scripts": {
+    "test": "./node_modules/.bin/coffee test/runtests.coffee"
+  },
   "directories": {
     "lib": "",
     "example": "./examples",

--- a/sip.js
+++ b/sip.js
@@ -71,7 +71,7 @@ function parseParams(data, hdr) {
   var re = /\s*;\s*([\w\-.!%*_+`'~]+)(?:\s*=\s*([\w\-.!%*_+`'~]+|"[^"\\]*(\\.[^"\\]*)*"))?/g; 
   
   for(var r = applyRegex(re, data); r; r = applyRegex(re, data)) {
-    hdr.params[r[1].toLowerCase()] = r[2];
+    hdr.params[r[1].toLowerCase()] = r[2] || null;
   }
 
   return hdr;

--- a/test/messages/_compute.js
+++ b/test/messages/_compute.js
@@ -1,0 +1,51 @@
+"use strict";
+/*
+Compute .json
+
+This script will parse the raw sip messages *.dat that are present
+in this directory and export the result in a file *.json.
+Note that an empty file .json has to be present in the dir.
+
+Be careful, check that the .json generated match the value 
+that is actually expected.
+
+*/
+
+let fs= require("fs");
+let path = require("path");
+let sip = require("../../");
+
+let encoding= "binary";
+
+let files = fs.readdirSync(__dirname);
+
+let names = [];
+
+for (let file of files) {
+
+    if (path.extname(file) !== ".json") continue;
+
+    names.push(path.basename(file, ".json"));
+
+}
+
+for (let name of names) {
+    
+    console.log(`${name}.dat => sip.parse => ${name}.json`);
+
+    let dat = fs.readFileSync(
+        path.join(__dirname, `${name}.dat`),
+        encoding
+    );
+
+    let json = JSON.stringify(sip.parse(dat), null, 2);
+
+    fs.writeFileSync(
+        path.join(__dirname, `${name}.json`),
+        json,
+        { "encoding": encoding }
+    );
+
+}
+
+console.log("DONE");

--- a/test/messages/longreq.json
+++ b/test/messages/longreq.json
@@ -12,7 +12,8 @@
       "uri": "sip:amazinglylongcallernameamazinglylongcallernameamazinglylongcallernameamazinglylongcallernameamazinglylongcallername@example.net",
       "params": {
         "tag": "12982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982982424",
-        "unknownheaderparamnamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamename": "unknowheaderparamvaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevalue"
+        "unknownheaderparamnamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamename": "unknowheaderparamvaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevalue",
+        "unknownvaluelessparamnameparamnameparamnameparamnameparamnameparamnameparamnameparamnameparamnameparamname": null
       }
     },
     "call-id": "longreq.onereallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongcallid",

--- a/test/messages/mpart01.json
+++ b/test/messages/mpart01.json
@@ -10,7 +10,8 @@
         "host": "127.0.0.1",
         "port": 5070,
         "params": {
-          "branch": "z9hG4bK-d87543-4dade06d0bdb11ee-1--d87543-"
+          "branch": "z9hG4bK-d87543-4dade06d0bdb11ee-1--d87543-",
+          "rport": null
         }
       }
     ],

--- a/test/messages/wsinv.json
+++ b/test/messages/wsinv.json
@@ -75,6 +75,7 @@
         "uri": "sip:jdrosen@example.com",
         "params": {
           "newparam": "newvalue",
+          "secondparam": null,
           "q": "0.33"
         }
       }

--- a/test/runtests.coffee
+++ b/test/runtests.coffee
@@ -13,7 +13,7 @@ runTests = (tests) ->
 modules = process.argv[2..process.argv.length]
 
 if modules.length == 0
-  modules = ['parser', 'digest', 'rport']
+  modules = ['parser', 'digest', 'rport', 'stream_parser']
 
 console.log modules
 

--- a/test/stream_parser.js
+++ b/test/stream_parser.js
@@ -1,0 +1,122 @@
+"use strict";
+
+let sip = require("../");
+let fs = require("fs");
+let path= require("path");
+
+function handleKeepAlive(success) {
+
+    let isSuccess= false; 
+
+    let rawMessageAsBinaryString= fs.readFileSync(path.join(__dirname, "messages", "baddate.dat"), "binary");
+
+    let streamParser = sip.makeStreamParser(
+        function (sipPacket) {
+
+            isSuccess= true;
+
+            console.log("ok test handleKeepAlive");
+
+            success();
+
+        }
+    );
+
+    for( let i=0; i<20000; i++)
+        streamParser("\r\n");
+
+    streamParser(rawMessageAsBinaryString);
+
+    console.assert(isSuccess, "Message has not been parsed");
+
+}
+
+function flood(success) {
+
+    let isSuccess= false;
+
+    let onMessage= function(sipPacket){ 
+
+        console.assert(false, "Message should not have been parsed"); 
+
+    };
+
+    let onFlood= function(){
+
+        isSuccess= true;
+
+        console.log("ok test flood");
+
+        success();
+
+    }
+
+    let maxBytesHeaders= 6048;
+
+    let streamParser = sip.makeStreamParser(onMessage, onFlood, maxBytesHeaders);
+
+    let floodData= "";
+
+    for (let i = 0; i < maxBytesHeaders; i++){
+
+        floodData+= "x";
+
+    }
+
+    streamParser(floodData);
+
+    streamParser("OVERFLOW!");
+
+    console.assert(isSuccess, "We have been buffering flood data");
+
+}
+
+function payloadFlood(success) {
+
+    let isSuccess = false;
+
+    let split = fs
+        .readFileSync(
+        path.join(__dirname, "messages", "baddate.dat"),
+        "binary"
+        )
+        .split("\r\n");
+
+    for (let i = 0; i <= split.length; i++)
+        if (split[i].match(/^Content-Length:\ ([0-9]+)$/)) {
+            split[i] = split[i].replace(/[0-9]+/, "999999999999");
+            break;
+        }
+
+
+    let rawMessageAsBinaryString = split.join("\r\n");
+
+    let onMessage= function(sipPacket){ 
+
+        console.assert(false, "Message should not have been parsed"); 
+
+    };
+
+    let onFlood= function(){
+
+        isSuccess= true;
+
+        console.log("ok test payloadFlood");
+
+        success();
+
+    }
+
+    let streamParser = sip.makeStreamParser(onMessage, onFlood);
+
+    streamParser(rawMessageAsBinaryString);
+
+    for( let i=0; i<100000; i++)
+        streamParser("FLOOD");
+
+    console.assert(isSuccess, "Payload Flood attack!");
+
+}
+
+
+exports.tests= [ handleKeepAlive, flood, payloadFlood ];


### PR DESCRIPTION
I realised that makeStreamParser had no implemented mechanism to prevent from flood.

Meaning that a peer transmiting random data that does not parse to a SIP message and does not contain CRLF*2 will be able to crash the server in no time.
This is due to the fact that the makeStreamParser function buffer all the received data until it came across a double CRLF.

An other easy way to take down this stack is to send a message with the Content-Length header value set to a enormous value then send random data until the server crash.

In this PR I offer to set boundary to the SIP header length and to the content length. 
Those value can be configured via the options object. 
When a flood attempt is detected then the source socket is closed.

Regards