### PR TITLE
Switched from uws to ws package due to deprecation.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,24 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
     "coffee-script": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
       "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
       "dev": true
     },
-    "uws": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-8.14.1.tgz",
-      "integrity": "sha1-3glhnzBfYXTVUWqcaULLEgkEsgs="
+    "ws": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.0.tgz",
+      "integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">=0.2.2"
   },
   "dependencies": {
-    "uws": "*"
+    "ws": "*"
   },
   "devDependencies": {
     "coffee-script": "~1.6.2"

--- a/sip.js
+++ b/sip.js
@@ -6,7 +6,7 @@ var dgram = require('dgram');
 var tls = require('tls');
 var os = require('os');
 var crypto = require('crypto');
-var WebSocket = require('uws');
+var WebSocket = require('ws');
 
 function debug(e) {
   if(e.stack) {


### PR DESCRIPTION
Resolves #130.

Have not tested with the websocket examples to verify those still work.

`ws` does look to be largely a drop-in replacement for `uws` though.